### PR TITLE
Remove unused and unneeded parameters

### DIFF
--- a/Allfiles/Labs/03/az104-03b-md-template.json
+++ b/Allfiles/Labs/03/az104-03b-md-template.json
@@ -14,20 +14,7 @@
         "diskSizeGb": {
             "type": "Int"
         },
-        "sourceResourceId": {
-            "type": "String"
-        },
-        "sourceUri": {
-            "type": "String"
-        },
-        "osType": {
-            "type": "String"
-        },
         "createOption": {
-            "type": "String"
-        },
-        "hyperVGeneration": {
-            "defaultValue": "V1",
             "type": "String"
         },
         "diskEncryptionSetType": {
@@ -52,7 +39,6 @@
                     "createOption": "[parameters('createOption')]"
                 },
                 "diskSizeGB": "[parameters('diskSizeGb')]",
-                "osType": "[parameters('osType')]",
                 "networkAccessPolicy": "[parameters('networkAccessPolicy')]"
             }
         }


### PR DESCRIPTION
# Module: AZ-104-MicrosoftAzureAdministrator
## Lab/Demo: 3B

Fixes # .
Changes proposed in this pull request:

- Removes unneeded and unused parameters in the Lab 03B for ARM templates.
- OsType isn't required and doesn't have a related parameter in the params file.
- Same for sourceResourceId, sourceUri, hyperVGeneration
